### PR TITLE
Implement basic editing & notification scheduler

### DIFF
--- a/Reminders/NotificationScheduler.swift
+++ b/Reminders/NotificationScheduler.swift
@@ -1,0 +1,32 @@
+import Foundation
+import UserNotifications
+
+/// Utility functions for scheduling and managing local notifications.
+struct NotificationScheduler {
+    static func schedule(_ reminder: Reminder) {
+        guard let id = reminder.id, let date = reminder.dateTime else { return }
+        let content = UNMutableNotificationContent()
+        content.title = reminder.title ?? ""
+        if let note = reminder.note { content.body = note }
+        content.sound = .default
+
+        let comps = Calendar.current.dateComponents([.year, .month, .day, .hour, .minute], from: date)
+        let trigger = UNCalendarNotificationTrigger(dateMatching: comps, repeats: reminder.recurrenceRule != nil)
+
+        let request = UNNotificationRequest(identifier: id.uuidString, content: content, trigger: trigger)
+        UNUserNotificationCenter.current().add(request) { error in
+            if let err = error { print("Notification scheduling error:", err) }
+        }
+    }
+
+    static func cancel(_ reminder: Reminder) {
+        if let id = reminder.id {
+            UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: [id.uuidString])
+        }
+    }
+
+    static func reschedule(_ reminder: Reminder) {
+        cancel(reminder)
+        schedule(reminder)
+    }
+}

--- a/Reminders/Recurrence.swift
+++ b/Reminders/Recurrence.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// Frequency options for repeating reminders.
+enum Recurrence: String, CaseIterable, Identifiable {
+    case none = "None"
+    case daily = "Daily"
+    case weekly = "Weekly"
+
+    var id: String { rawValue }
+
+    /// Recurrence rule string used for UNCalendarNotificationTrigger
+    var rrule: String? {
+        switch self {
+        case .none: return nil
+        case .daily: return "FREQ=DAILY;INTERVAL=1"
+        case .weekly: return "FREQ=WEEKLY;INTERVAL=1"
+        }
+    }
+
+    /// Convert a stored recurrence rule string back to a Recurrence value.
+    static func from(rule: String?) -> Recurrence {
+        switch rule {
+        case "FREQ=DAILY;INTERVAL=1": return .daily
+        case "FREQ=WEEKLY;INTERVAL=1": return .weekly
+        default: return .none
+        }
+    }
+}

--- a/Reminders/Views/AddReminderView.swift
+++ b/Reminders/Views/AddReminderView.swift
@@ -11,21 +11,6 @@ struct AddReminderView: View {
     @State private var dateTime: Date = Date()
     @State private var recurrenceSelection: Recurrence = .none
 
-    enum Recurrence: String, CaseIterable, Identifiable {
-        case none = "None"
-        case daily = "Daily"
-        case weekly = "Weekly"
-
-        var id: String { rawValue }
-        var rrule: String? {
-            switch self {
-            case .none: return nil
-            case .daily: return "FREQ=DAILY;INTERVAL=1"
-            case .weekly: return "FREQ=WEEKLY;INTERVAL=1"
-            }
-        }
-    }
-
     var body: some View {
         NavigationView {
             Form {
@@ -68,27 +53,11 @@ struct AddReminderView: View {
 
         do {
             try viewContext.save()
-            scheduleNotification(for: rem)
+            NotificationScheduler.schedule(rem)
             presentationMode.wrappedValue.dismiss()
         } catch {
             print("Error saving reminder:", error)
         }
     }
 
-    private func scheduleNotification(for rem: Reminder) {
-        let content = UNMutableNotificationContent()
-        content.title = rem.title ?? ""
-        content.body = rem.note ?? ""
-        content.sound = .default
-
-        let comps = Calendar.current.dateComponents([.year, .month, .day, .hour, .minute], from: rem.dateTime!)
-        let trigger = UNCalendarNotificationTrigger(dateMatching: comps, repeats: rem.recurrenceRule != nil)
-
-        let request = UNNotificationRequest(identifier: rem.id!.uuidString, content: content, trigger: trigger)
-        UNUserNotificationCenter.current().add(request) { error in
-            if let err = error {
-                print("Notification scheduling error:", err)
-            }
-        }
-    }
 }

--- a/Reminders/Views/ContentView.swift
+++ b/Reminders/Views/ContentView.swift
@@ -14,20 +14,22 @@ struct ContentView: View {
         NavigationView {
             List {
                 ForEach(reminders) { rem in
-                    HStack {
-                        VStack(alignment: .leading) {
-                            Text(rem.title ?? "No Title")
-                                .font(.headline)
-                            if let note = rem.note, !note.isEmpty {
-                                Text(note)
-                                    .font(.subheadline)
+                    NavigationLink(destination: EditReminderView(reminder: rem)) {
+                        HStack {
+                            VStack(alignment: .leading) {
+                                Text(rem.title ?? "No Title")
+                                    .font(.headline)
+                                if let note = rem.note, !note.isEmpty {
+                                    Text(note)
+                                        .font(.subheadline)
+                                        .foregroundColor(.secondary)
+                                }
+                            }
+                            Spacer()
+                            if let date = rem.dateTime {
+                                Text(date, style: .time)
                                     .foregroundColor(.secondary)
                             }
-                        }
-                        Spacer()
-                        if let date = rem.dateTime {
-                            Text(date, style: .time)
-                                .foregroundColor(.secondary)
                         }
                     }
                 }

--- a/Reminders/Views/EditReminderView.swift
+++ b/Reminders/Views/EditReminderView.swift
@@ -1,0 +1,62 @@
+import SwiftUI
+import CoreData
+import UserNotifications
+
+/// View for editing an existing reminder.
+struct EditReminderView: View {
+    @Environment(\.managedObjectContext) private var viewContext
+    @Environment(\.presentationMode) private var presentationMode
+
+    @ObservedObject var reminder: Reminder
+
+    @State private var title: String
+    @State private var note: String
+    @State private var dateTime: Date
+    @State private var recurrenceSelection: Recurrence
+
+    init(reminder: Reminder) {
+        _reminder = ObservedObject(wrappedValue: reminder)
+        _title = State(initialValue: reminder.title ?? "")
+        _note = State(initialValue: reminder.note ?? "")
+        _dateTime = State(initialValue: reminder.dateTime ?? Date())
+        _recurrenceSelection = State(initialValue: Recurrence.from(rule: reminder.recurrenceRule))
+    }
+
+    var body: some View {
+        Form {
+            Section(header: Text("Details")) {
+                TextField("Title", text: $title)
+                TextField("Note", text: $note)
+            }
+            Section(header: Text("When")) {
+                DatePicker("Date & Time", selection: $dateTime)
+                Picker("Repeat", selection: $recurrenceSelection) {
+                    ForEach(Recurrence.allCases) { freq in
+                        Text(freq.rawValue).tag(freq)
+                    }
+                }
+                .pickerStyle(SegmentedPickerStyle())
+            }
+        }
+        .navigationTitle("Edit Reminder")
+        .navigationBarItems(
+            trailing: Button("Save") { saveChanges() }
+                .disabled(title.isEmpty)
+        )
+    }
+
+    private func saveChanges() {
+        reminder.title = title
+        reminder.note = note.isEmpty ? nil : note
+        reminder.dateTime = dateTime
+        reminder.recurrenceRule = recurrenceSelection.rrule
+
+        do {
+            try viewContext.save()
+            NotificationScheduler.reschedule(reminder)
+            presentationMode.wrappedValue.dismiss()
+        } catch {
+            print("Error updating reminder:", error)
+        }
+    }
+}

--- a/Reminders/Views/ReminderDetailView.swift
+++ b/Reminders/Views/ReminderDetailView.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+/// Simple read-only display of a reminder's information.
+struct ReminderDetailView: View {
+    @ObservedObject var reminder: Reminder
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text(reminder.title ?? "No Title")
+                .font(.title2)
+            if let note = reminder.note, !note.isEmpty {
+                Text(note)
+            }
+            if let date = reminder.dateTime {
+                Text(date, style: .date)
+                Text(date, style: .time)
+            }
+            if let rule = reminder.recurrenceRule {
+                Text("Repeats: \(Recurrence.from(rule: rule).rawValue)")
+            }
+            Spacer()
+        }
+        .padding()
+        .navigationTitle("Reminder Details")
+    }
+}


### PR DESCRIPTION
## Summary
- centralize recurrence options in `Recurrence` enum
- implement `NotificationScheduler` for scheduling and cancelling reminders
- allow creating reminders with scheduled notifications
- add `EditReminderView` for editing existing reminders
- show reminders in list with navigation to edit view
- add simple `ReminderDetailView`

## Testing
- `xcodebuild -version` *(fails: command not found)*
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_684db18d7790832799fff56662e2b85f