### PR TITLE
Add Person and MemoryNote Core Data entities

### DIFF
--- a/Reminders/MemoryNote.swift
+++ b/Reminders/MemoryNote.swift
@@ -1,0 +1,9 @@
+import CoreData
+
+/// Text note associated with a person.
+class MemoryNote: NSManagedObject {
+    @NSManaged var id: UUID?
+    @NSManaged var text: String?
+    @NSManaged var timestamp: Date?
+    @NSManaged var person: Person?
+}

--- a/Reminders/Person+Notes.swift
+++ b/Reminders/Person+Notes.swift
@@ -1,0 +1,9 @@
+import CoreData
+
+extension Person {
+    @objc(addNotesObject:)
+    @NSManaged public func addToNotes(_ value: MemoryNote)
+
+    @objc(removeNotesObject:)
+    @NSManaged public func removeFromNotes(_ value: MemoryNote)
+}

--- a/Reminders/Person.swift
+++ b/Reminders/Person.swift
@@ -1,0 +1,9 @@
+import CoreData
+
+/// Represents a person the user wants to remember.
+class Person: NSManagedObject {
+    @NSManaged var id: UUID?
+    @NSManaged var name: String?
+    @NSManaged var lastContactedAt: Date?
+    @NSManaged var notes: NSSet?
+}

--- a/Reminders/ReminderApp.xcdatamodeld/ReminderApp.xcdatamodel/contents
+++ b/Reminders/ReminderApp.xcdatamodeld/ReminderApp.xcdatamodel/contents
@@ -15,4 +15,16 @@
         <attribute name="timestamp" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <relationship name="reminder" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Reminder" inverseName="snoozeRecords" inverseEntity="Reminder"/>
     </entity>
+    <entity name="Person" representedClassName="Person" syncable="YES" codeGenerationType="class">
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="name" attributeType="String"/>
+        <attribute name="lastContactedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <relationship name="notes" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="MemoryNote" inverseName="person" inverseEntity="MemoryNote"/>
+    </entity>
+    <entity name="MemoryNote" representedClassName="MemoryNote" syncable="YES" codeGenerationType="class">
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="text" optional="YES" attributeType="String"/>
+        <attribute name="timestamp" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <relationship name="person" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Person" inverseName="notes" inverseEntity="Person"/>
+    </entity>
 </model>

--- a/Reminders/Views/AddPersonView.swift
+++ b/Reminders/Views/AddPersonView.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+import CoreData
+
+/// View for creating a new person entry.
+struct AddPersonView: View {
+    @Environment(\.managedObjectContext) private var viewContext
+    @Environment(\.presentationMode) private var presentationMode
+
+    @State private var name: String = ""
+
+    var body: some View {
+        NavigationView {
+            Form {
+                TextField("Name", text: $name)
+            }
+            .navigationTitle("New Person")
+            .navigationBarItems(
+                leading: Button("Cancel") { presentationMode.wrappedValue.dismiss() },
+                trailing: Button("Save") { save() }.disabled(name.isEmpty)
+            )
+        }
+    }
+
+    private func save() {
+        let person = Person(context: viewContext)
+        person.id = UUID()
+        person.name = name
+        person.lastContactedAt = Date()
+        do {
+            try viewContext.save()
+            presentationMode.wrappedValue.dismiss()
+        } catch {
+            print("Error saving person:", error)
+        }
+    }
+}
+
+#Preview {
+    AddPersonView()
+        .environment(\.managedObjectContext,
+                     PersistenceController.shared.container.viewContext)
+}

--- a/Reminders/Views/ContentView.swift
+++ b/Reminders/Views/ContentView.swift
@@ -1,70 +1,17 @@
 import SwiftUI
-import CoreData
 
+/// Root view showing reminders and people tabs.
 struct ContentView: View {
-    @Environment(\.managedObjectContext) private var viewContext
-
-    @FetchRequest(
-        sortDescriptors: [NSSortDescriptor(keyPath: \Reminder.dateTime, ascending: true)],
-        animation: .default
-    )
-    private var reminders: FetchedResults<Reminder>
-
-    @State private var showingAdd = false
-
     var body: some View {
-        NavigationView {
-            List {
-                ForEach(reminders) { rem in
-                    NavigationLink(destination: ReminderDetailView(reminder: rem)) {
-                        HStack {
-                            VStack(alignment: .leading) {
-                                Text(rem.title ?? "No Title")
-                                    .font(.headline)
-                                if let note = rem.note, !note.isEmpty {
-                                    Text(note)
-                                        .font(.subheadline)
-                                        .foregroundColor(.secondary)
-                                }
-                            }
-                            Spacer()
-                            if let date = rem.dateTime {
-                                Text(date, style: .time)
-                                    .foregroundColor(.secondary)
-                            }
-                        }
-                    }
+        TabView {
+            RemindersListView()
+                .tabItem {
+                    Label("Reminders", systemImage: "list.bullet")
                 }
-                .onDelete(perform: deleteReminders)
-            }
-            .navigationTitle("Reminders")
-            .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    Button(action: { showingAdd.toggle() }) {
-                        Image(systemName: "plus")
-                    }
+            PeopleView()
+                .tabItem {
+                    Label("People", systemImage: "person.2")
                 }
-            }
-            .sheet(isPresented: $showingAdd) {
-                AddReminderView()
-                    .environment(\.managedObjectContext, viewContext)
-            }
-        }
-    }
-
-    private func deleteReminders(at offsets: IndexSet) {
-        offsets.map { reminders[$0] }.forEach { rem in
-            NotificationScheduler.cancel(rem)
-            viewContext.delete(rem)
-        }
-        saveContext()
-    }
-
-    private func saveContext() {
-        do {
-            try viewContext.save()
-        } catch {
-            print("Error saving context:\(error)")
         }
     }
 }

--- a/Reminders/Views/PeopleView.swift
+++ b/Reminders/Views/PeopleView.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+import CoreData
+
+/// Lists saved people.
+struct PeopleView: View {
+    @Environment(\.managedObjectContext) private var viewContext
+
+    @FetchRequest(
+        sortDescriptors: [NSSortDescriptor(keyPath: \Person.name, ascending: true)],
+        animation: .default
+    )
+    private var people: FetchedResults<Person>
+
+    @State private var showingAdd = false
+
+    var body: some View {
+        NavigationView {
+            List {
+                ForEach(people) { person in
+                    NavigationLink(destination: PersonDetailView(person: person)) {
+                        Text(person.name ?? "Untitled")
+                    }
+                }
+                .onDelete(perform: deletePeople)
+            }
+            .navigationTitle("People")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button(action: { showingAdd.toggle() }) {
+                        Image(systemName: "plus")
+                    }
+                }
+            }
+            .sheet(isPresented: $showingAdd) {
+                AddPersonView()
+                    .environment(\.managedObjectContext, viewContext)
+            }
+        }
+    }
+
+    private func deletePeople(at offsets: IndexSet) {
+        offsets.map { people[$0] }.forEach(viewContext.delete)
+        try? viewContext.save()
+    }
+}
+
+#Preview {
+    PeopleView()
+        .environment(\.managedObjectContext,
+                     PersistenceController.shared.container.viewContext)
+}

--- a/Reminders/Views/PersonDetailView.swift
+++ b/Reminders/Views/PersonDetailView.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+/// Displays information about a person.
+struct PersonDetailView: View {
+    @ObservedObject var person: Person
+
+    var body: some View {
+        Form {
+            Text(person.name ?? "")
+                .font(.headline)
+            if let last = person.lastContactedAt {
+                Text("Last contacted: \(last.formatted())")
+            }
+        }
+        .navigationTitle("Person")
+    }
+}
+
+#Preview {
+    let context = PersistenceController.shared.container.viewContext
+    let p = Person(context: context)
+    p.name = "Sample"
+    return PersonDetailView(person: p)
+}

--- a/Reminders/Views/RemindersListView.swift
+++ b/Reminders/Views/RemindersListView.swift
@@ -1,0 +1,76 @@
+import SwiftUI
+import CoreData
+
+struct RemindersListView: View {
+    @Environment(\.managedObjectContext) private var viewContext
+
+    @FetchRequest(
+        sortDescriptors: [NSSortDescriptor(keyPath: \Reminder.dateTime, ascending: true)],
+        animation: .default
+    )
+    private var reminders: FetchedResults<Reminder>
+
+    @State private var showingAdd = false
+
+    var body: some View {
+        NavigationView {
+            List {
+                ForEach(reminders) { rem in
+                    NavigationLink(destination: ReminderDetailView(reminder: rem)) {
+                        HStack {
+                            VStack(alignment: .leading) {
+                                Text(rem.title ?? "No Title")
+                                    .font(.headline)
+                                if let note = rem.note, !note.isEmpty {
+                                    Text(note)
+                                        .font(.subheadline)
+                                        .foregroundColor(.secondary)
+                                }
+                            }
+                            Spacer()
+                            if let date = rem.dateTime {
+                                Text(date, style: .time)
+                                    .foregroundColor(.secondary)
+                            }
+                        }
+                    }
+                }
+                .onDelete(perform: deleteReminders)
+            }
+            .navigationTitle("Reminders")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button(action: { showingAdd.toggle() }) {
+                        Image(systemName: "plus")
+                    }
+                }
+            }
+            .sheet(isPresented: $showingAdd) {
+                AddReminderView()
+                    .environment(\.managedObjectContext, viewContext)
+            }
+        }
+    }
+
+    private func deleteReminders(at offsets: IndexSet) {
+        offsets.map { reminders[$0] }.forEach { rem in
+            NotificationScheduler.cancel(rem)
+            viewContext.delete(rem)
+        }
+        saveContext()
+    }
+
+    private func saveContext() {
+        do {
+            try viewContext.save()
+        } catch {
+            print("Error saving context:\(error)")
+        }
+    }
+}
+
+#Preview {
+    RemindersListView()
+        .environment(\.managedObjectContext,
+                     PersistenceController.shared.container.viewContext)
+}


### PR DESCRIPTION
## Summary
- extend the data model with **Person** and **MemoryNote** entities
- create NSManagedObject classes for the new entities
- add basic CRUD views for managing people
- split reminder list into `RemindersListView` and new tabbed `ContentView`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ec0a38b848327a3ec58834c619ef3